### PR TITLE
[Dayeon][FIXED] when ###.txt is blank.

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -9,7 +9,7 @@ Your contribution will be of great help to the VMeta project.<br/>
 
 ## Contribute Guide
 
-See <a href="./README.md">README</a> file for general information on VMeta. <br/>
+See <a href="./README.md">README</a> file to get general information on VMeta. <br/>
 VMeta project and everyone participating in this project is governed by the <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/">CODE_OF_CONDUCT</a>.
 
 

--- a/EXECUTE_EN.md
+++ b/EXECUTE_EN.md
@@ -17,6 +17,7 @@ If you run VMeta on local, change the port number to 8000 to avoid conflict.
 ```
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_APP=uploadApi
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_DEBUG=1
+(venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_ENV=development
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > flask run --host 127.0.0.1 --port 8000
 ```
 
@@ -43,5 +44,6 @@ App hstack contains main pages of VMeta.
 ```
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_APP=hstack
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_DEBUG=1
+(venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_ENV=development
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > flask run
 ```

--- a/EXECUTE_KO.md
+++ b/EXECUTE_KO.md
@@ -17,6 +17,7 @@ local에서 실행할 경우 port번호를 8000번으로 바꿔 실행합니다.
 ```
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_APP=uploadApi
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_DEBUG=1
+(venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_ENV=development
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > flask run --host 127.0.0.1 --port 8000
 ```
 
@@ -43,5 +44,6 @@ hstack은 메인 페이지에 해당합니다.
 ```
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_APP=hstack
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_DEBUG=1
+(venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > set FLASK_ENV=development
 (venv) E:\Workspace\VideoMetaSystem\FLASK\hstack > flask run
 ```

--- a/FLASK/hstack/hstack/views/performanc_views.py
+++ b/FLASK/hstack/hstack/views/performanc_views.py
@@ -175,7 +175,10 @@ def ratio():
                     timeCnt += datetime2sec(endTime - startTime)
 
             idViewDict[key] = viewCnt
-            idTimeDict[key] = round(timeCnt / viewCnt, 2)
+            if (viewCnt != 0):
+                idTimeDict[key] = round(timeCnt / viewCnt, 2)
+            else:
+                idTimeDict[key] = 0
 
     idViewList = sorted(idViewDict.items(), key = lambda item: item[1], reverse = True)
     idViewMeta = list()
@@ -358,8 +361,10 @@ def performance_videoviews():
                     endTime = datetime.datetime.strptime(cmd[1], datetime_format)
                     timeCnt += datetime2sec(endTime - startTime)
 
-            idViewDict[key] = viewCnt
-            idTimeDict[key] = round(timeCnt / viewCnt, 2)
+            if (viewCnt != 0):
+                idTimeDict[key] = round(timeCnt / viewCnt, 2)
+            else:
+                idTimeDict[key] = 0
 
     idViewList = sorted(idViewDict.items(), key = lambda item: item[1], reverse = True)
     idViewMeta = list()
@@ -466,7 +471,10 @@ def performance_detailFile(pk):
                     searchDict[key] = 1
 
         metadataDict['view'] = viewCnt
-        metadataDict['avgTime'] = round(timeCnt / viewCnt, 2)
+        if (viewCnt != 0):
+            metadataDict['avgTime'] = round(timeCnt / viewCnt, 2)
+        else:
+            metadataDict['avgTime'] = 0
 
     else:
         metadataDict['view'] = 0

--- a/INSTALL_EN.md
+++ b/INSTALL_EN.md
@@ -4,7 +4,7 @@
 
 > This document describes how to install VMeta in your local environment.<br/>
 > It is base on <b>Windows10</b>.<br/><br/>
-> Last Edit : 2022.10.06
+> Last Edit : 2022.10.20
 
 <br/>
 

--- a/INSTALL_KO.md
+++ b/INSTALL_KO.md
@@ -5,7 +5,7 @@
 
 > 본 문서는 local 환경에서의 VMeta 설치 방법에 대해 기술합니다. <br/>
 > <b>Windows10</b>를 기준으로 작성되었습니다.<br/><br/>
-> Last Edit : 2022.10.06
+> Last Edit : 2022.10.20
 
 <br/>
 

--- a/LICENSE_3rd.md
+++ b/LICENSE_3rd.md
@@ -38,9 +38,9 @@ http://ffmpeg.org/doxygen/4.4/md_LICENSE.html
 
 <br/>
 
-<b> Tesseract by tesseract-OCR</b><br/>
+<b> Tesseract by UB-Mannheim</b><br/>
 License : Apache 2.0<br/>
-https://tesseract-ocr.github.io/tessdoc/Installation.html
+https://github.com/UB-Mannheim/tesseract/blob/main/LICENSE
 
 <br/>
 
@@ -65,3 +65,10 @@ https://github.com/opencv/opencv-python/blob/4.x/LICENSE.txt
 <b> startbootstrap-sb-admin by StartBootstrap</b><br/>
 License : MIT<br/>
 https://github.com/startbootstrap/startbootstrap-sb-admin/blob/master/LICENSE
+
+<br/>
+
+<b> ETRI Open API</b><br/>
+VMeta uses ETRI's Open API across speech recognition and language processing technologies.<br/>
+The license of the ETRI Open API is in accordance with the requirements of the link below.<br/>
+https://aiopen.etri.re.kr/service_guide.php


### PR DESCRIPTION
\### : video ID

모니터링 페이지에서 특정 로그파일이 없는 경우에 대한 에러처리
- ###.txt가 file인지 확인 : file인 경우에만 조회수/평균재생시간 계산
- ###.txt가 file이나 공란인경우 : 조회수가 0인경우 평균재생시간 역시 0으로 계산

그 외 LICENSE 파일 업데이트
- ETRI Open API 관련 내용 추가