### PR TITLE
[ADD] support PDF file in makePPT.py

### DIFF
--- a/DJANGO/hstack/core/makePPT.py
+++ b/DJANGO/hstack/core/makePPT.py
@@ -5,19 +5,12 @@ import tempfile
 from . import models
 from pptx import Presentation
 from pptx.util import Inches
-from fpdf import FPDF
 
 
 # 상수 설정
 OS = platform.system()
 
-def convertPPTtoPDF(pptPath):                                   #필요에 따라 PPT 파일 경로를 매개변수로 받고, PPT를 열어 PDF로 저장한 뒤, PDF 파일 경로를 반환
-    pdfPath = os.path.splitext(pptPath)[0] + '.pdf'
-    ppt = Presentation(pptPath)
-    ppt.save(pdfPath)
-    return pdfPath
-
-def getPPTFile(videoId, convert_to_pdf=False):
+def getPPTFile(videoId):
     pptFile = Presentation()
     videoPathObj = models.Videopath.objects.get(id=videoId)     #DB에서 videoId에 해당하는 객체를 가져옴
     imageFilePath = videoPathObj.imageaddr                      #DB에서 imageAddr 추출
@@ -28,10 +21,7 @@ def getPPTFile(videoId, convert_to_pdf=False):
     else : 
         imagePath = (imageFilePath + "\\").replace("\\", "/")
     
-    print(imageFilePath)
-    print(imagePath)
     imageList = os.listdir(imageFilePath)
-    print(imageList)
 
     slide_layout = pptFile.slide_layouts[6]
 
@@ -48,8 +38,37 @@ def getPPTFile(videoId, convert_to_pdf=False):
 
     pptFile.save(imagePath + title + '.pptx')
 
-    if convert_to_pdf:
-        pdfPath = convertPPTtoPDF(imagePath + title + '.pptx')
-        return pptPathRel, pdfPath
-
     return pptPathRel
+
+# idea from PR82 by @minzix
+# PDF로 저장
+from img2pdf import convert
+
+def makePDFFile(videoId): 
+    videoPathObj = models.Videopath.objects.get(id=videoId)     #DB에서 videoId에 해당하는 객체를 가져옴
+    imageFilePath = videoPathObj.imageaddr                      #DB에서 imageAddr 추출
+    title = videoPathObj.title
+
+    if OS == "Windows" : 
+        imagePath = (imageFilePath + "\\").replace("/", "\\")
+    else : 
+        imagePath = (imageFilePath + "\\").replace("\\", "/")
+
+    imageList = os.listdir(imageFilePath)
+   
+    if OS == "Windows": 
+        pdfPathRel = "../../../media/Uploaded/Image/" + imageFilePath.split('Image\\')[1].replace("\\", "/") + "/" + title + '.pdf'
+    else: 
+        pdfPathRel = "../../../media/Uploaded/Image/" + imageFilePath.split('Image/')[1] + "/" + title + ".pdf"
+
+    imageList = os.listdir(imagePath)
+    
+    with open(pdfPathRel, "wb") as pf:
+        pdfList = []
+
+        for image in imageList:
+            if image.startswith("L") or image.startswith("P"):
+                pdfList.append(imagePath + image)
+        
+        pdfFile = convert(pdfList)
+        pf.write(pdfFile)

--- a/DJANGO/hstack/core/makePPT.py
+++ b/DJANGO/hstack/core/makePPT.py
@@ -1,15 +1,23 @@
 import os
 import platform
+import tempfile
 
 from . import models
 from pptx import Presentation
 from pptx.util import Inches
+from fpdf import FPDF
 
 
 # 상수 설정
 OS = platform.system()
 
-def getPPTFile(videoId):
+def convertPPTtoPDF(pptPath):                                   #필요에 따라 PPT 파일 경로를 매개변수로 받고, PPT를 열어 PDF로 저장한 뒤, PDF 파일 경로를 반환
+    pdfPath = os.path.splitext(pptPath)[0] + '.pdf'
+    ppt = Presentation(pptPath)
+    ppt.save(pdfPath)
+    return pdfPath
+
+def getPPTFile(videoId, convert_to_pdf=False):
     pptFile = Presentation()
     videoPathObj = models.Videopath.objects.get(id=videoId)     #DB에서 videoId에 해당하는 객체를 가져옴
     imageFilePath = videoPathObj.imageaddr                      #DB에서 imageAddr 추출
@@ -33,12 +41,15 @@ def getPPTFile(videoId):
             slide = pptFile.slides.add_slide(slide_layout)
             slide.shapes.add_picture(imagePath + image, 0, 0, pptFile.slide_width, pptFile.slide_height)
     
-
-    if OS == "Windows" : 
+    if OS == "Windows": 
         pptPathRel = "../../../media/Uploaded/Image/" + imageFilePath.split('Image\\')[1].replace("\\", "/") + "/" + title + '.pptx'
-    else : 
+    else: 
         pptPathRel = "../../../media/Uploaded/Image/" + imageFilePath.split('Image/')[1] + "/" + title + ".pptx"
 
     pptFile.save(imagePath + title + '.pptx')
+
+    if convert_to_pdf:
+        pdfPath = convertPPTtoPDF(imagePath + title + '.pptx')
+        return pptPathRel, pdfPath
 
     return pptPathRel

--- a/FLASK/hstack/hstack/makePPT.py
+++ b/FLASK/hstack/hstack/makePPT.py
@@ -52,7 +52,7 @@ def getPPTFile(fileURL, title):
 
 # idea from PR82 by @minzix
 
-# PPT를 열어 PDF로 저장
+# PDF로 저장
 from img2pdf import convert
 
 def makePDFFile(fileURL, title): 

--- a/FLASK/hstack/hstack/makePPT.py
+++ b/FLASK/hstack/hstack/makePPT.py
@@ -45,9 +45,29 @@ def getPPTFile(fileURL, title):
             path = os.path.join(imagePath, image)
             slide = pptFile.slides.add_slide(slide_layout)
             slide.shapes.add_picture(path, 0, 0, pptFile.slide_width, pptFile.slide_height)
-    
-
-    title = "extractedPPT"
         
-    pptPathRel = os.path.join(os.path.dirname(fileURL), title + '.pptx')
+    pptPathRel = os.path.join(os.path.dirname(fileURL), title + '.ppt')
     pptFile.save(pptPathRel)
+
+
+# idea from PR82 by @minzix
+
+# PPT를 열어 PDF로 저장
+from img2pdf import convert
+
+def makePDFFile(fileURL, title): 
+    pdfPathRel = os.path.join(os.path.dirname(fileURL), title + '.pdf')
+    imagePath = os.path.join(os.path.dirname(fileURL), 'Image')
+
+    imageList = os.listdir(imagePath)
+    
+    with open(pdfPathRel, "wb") as pf:
+        pdfList = []
+
+        for image in imageList:
+            if image.startswith("L") or image.startswith("P"):
+                path = os.path.join(imagePath, image)
+                pdfList.append(path)
+        
+        pdfFile = convert(pdfList)
+        pf.write(pdfFile)

--- a/FLASK/hstack/hstack/static/js/videoAction.js
+++ b/FLASK/hstack/hstack/static/js/videoAction.js
@@ -132,11 +132,10 @@ function downloadImg(folderName){
     );
 }
 
-function downloadPPT(path, title){
-    console.log(`hello ${path}, ${title}`);
+function downloadFILE(extension, path, title){
     var element = document.createElement('form');
     element.setAttribute('method', 'GET');
-    element.setAttribute('action', `/detail/download/${path}/${title}`);
+    element.setAttribute('action', `/detail/download/${extension}/${path}/${title}`);
     document.body.appendChild(element);
     element.submit();
     document.body.removeChild(element);

--- a/FLASK/hstack/hstack/templates/detail.html
+++ b/FLASK/hstack/hstack/templates/detail.html
@@ -218,12 +218,19 @@ detail.html
                                             <span class="sceneDownloadBtn">저장</span><br>
                                             <span class="sceneDownloadBtn">(jpg)</span>
                                         </button>
-                                        <button id="downloadImg" type="button" onclick="downloadPPT('{{pptPath}}', 'extractedPPT')">
+                                        <button id="downloadImg" type="button" onclick="downloadFILE('ppt', '{{pptPath}}', 'extracted')">
                                             <img id="down" src="{{ url_for('static', filename='img/download.png') }}">
                                             <br>
                                             <span lass="sceneDownloadBtn">장면</span><br>
                                             <span lass="sceneDownloadBtn">저장</span><br>
                                             <span lass="sceneDownloadBtn">(ppt)</span>
+                                        </button>
+                                        <button id="downloadImg" type="button" onclick="downloadFILE('pdf', '{{pptPath}}', 'extracted')">
+                                            <img id="down" src="{{ url_for('static', filename='img/download.png') }}">
+                                            <br>
+                                            <span lass="sceneDownloadBtn">장면</span><br>
+                                            <span lass="sceneDownloadBtn">저장</span><br>
+                                            <span lass="sceneDownloadBtn">(pdf)</span>
                                         </button>
                                     </div>
                                     <div class="searchScroll">

--- a/FLASK/hstack/hstack/views/detail_views.py
+++ b/FLASK/hstack/hstack/views/detail_views.py
@@ -54,9 +54,9 @@ def data(filepath):
     else :
         return send_from_directory('../media', filepath.split('media/')[1])
 
-@bp.route('/detail/download/<string:path>/<string:title>')
-def download(path, title):
-    filepath = os.path.join('..', app.config.get('UPLOAD_FILE_DIR'), path, title+".pptx")
+@bp.route('/detail/download/<string:extension>/<string:path>/<string:title>')
+def download(extension, path, title):
+    filepath = os.path.join('..', app.config.get('UPLOAD_FILE_DIR'), path, title+'.'+extension)
     return send_file(filepath)
 
 @bp.route('/detail/<int:pk>', methods=['GET'])
@@ -77,8 +77,13 @@ def detailFile(pk):
     pptImage = makePPT.getPPTImage(videoPath)
 
     # PPT 파일 생성
-    title = DB.session.query(Videopath).filter(Videopath.id == pk).first().title
+    # TODO : use video title for make ppt/pdf
+    # title = DB.session.query(Videopath).filter(Videopath.id == pk).first().title
+    title = 'extracted'
     makePPT.getPPTFile(videoPath, title)
+
+    # PPT 파일 바탕으로 PDF 파일 생성
+    makePPT.makePDFFile(videoPath, title)
 
     # PPT 파일을 얻기 위한 폴더명 얻기
     if OS == "Windows":

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,6 +90,7 @@ Werkzeug==2.1.2
 wrapt==1.12.1
 XlsxWriter==3.0.3
 zipp==3.8.1
+img2pdf==0.4.4
 
 keras==2.7.0
 keras-nightly==2.5.0.dev2021032900


### PR DESCRIPTION
Accepting the opinion of #82 
Add function that supports PDF file in makePPT.py.
(Both Django, Flask)

First, I tried to using ppt2pdf based on #82 ,
But it has some problems because VMeta is using "PPTX" file.

So, I designed the logic as below.
1. get Image files from server (like function 'makePPT()')
2. added all of these files in pdf file.
3. saved 2.

But, the file name is still "extracted.pptx" and "extracted.pdf"
I think we should upgrade this to video name.